### PR TITLE
Implement Late Move Reduction

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -1,6 +1,6 @@
 use crate::bitboard::{
-    AddPiece, Bitboard, ClearBit, GetBit, New, PieceItr, Shift, INIT_W_BISHOPS, INIT_W_KING,
-    INIT_W_KNIGHTS, INIT_W_QUEEN, INIT_W_ROOKS, RANK1, RANK2, RANK7, RANK8,
+    AddPiece, Bitboard, ClearBit, GetBit, New, Shift, INIT_W_BISHOPS, INIT_W_KING, INIT_W_KNIGHTS,
+    INIT_W_QUEEN, INIT_W_ROOKS, RANK1, RANK2, RANK7, RANK8,
 };
 use crate::chess_move::{Move, MoveType};
 use crate::piece::PieceType::Rook;

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -408,6 +408,12 @@ pub fn attacks_to(pos: &BoardState, square: Square, lookup: &Lookup) -> Bitboard
     (pawns | rooks | bishops | queens | knights | king) & pos.bb_for_color(!us)
 }
 
+pub fn is_in_check(pos: &BoardState, lookup: &Lookup) -> bool {
+    let king_square = king_square(pos);
+    let checkers: Bitboard = attacks_to(pos, king_square, lookup);
+    checkers.count_ones() != 0
+}
+
 /// Calculates the ray strictly inclusive between s1 and s2
 fn ray_between(s1: Square, s2: Square, lookup: &Lookup) -> Bitboard {
     let full: Bitboard = !0;

--- a/src/search/alpha_beta.rs
+++ b/src/search/alpha_beta.rs
@@ -1,4 +1,3 @@
-use std::cmp::{max, min};
 use std::time::Instant;
 
 use itertools::Itertools;

--- a/src/search/alpha_beta.rs
+++ b/src/search/alpha_beta.rs
@@ -160,11 +160,11 @@ impl AlphaBeta {
             return Some(s);
         }
 
-            let is_leftmost_node = if ply % 2 == 0 {
-                alpha == NEG_INF && beta == INF
-            } else {
-                alpha == INF && beta == NEG_INF
-            };
+        let is_leftmost_node = if ply % 2 == 0 {
+            alpha == NEG_INF && beta == INF
+        } else {
+            alpha == INF && beta == NEG_INF
+        };
 
         // If we haven't found a best move to search first yet, and we are on a left-most node,
         // then perform an IID search to determine the best node to search first
@@ -190,48 +190,9 @@ impl AlphaBeta {
 
             let n = if is_first_move {
                 is_first_move = false;
-                self.alpha_beta(&mut new_pos, -beta, -alpha, depth-1, ply+1)
+                self.alpha_beta(&mut new_pos, -beta, -alpha, depth - 1, ply + 1)
             } else {
-                let in_check = is_in_check(&new_pos, &self.gen.lookup);
-                let mut r = 0;
-
-                let can_late_move_reduce = 
-                !is_leftmost_node &&
-                !in_check &&
-                !mv.mv.is_capture() &&
-                !mv.mv.is_promotion();
-
-                if can_late_move_reduce && depth > 2 {
-                    r += 1;
-                    if depth > 4 {
-                        r += depth / 4;
-                    }
-                }
-
-                let mut tmp = self.alpha_beta(&mut new_pos, -alpha - 1, -alpha, depth - r - 1, ply + 1);
-                if tmp.is_none() {
-                    return None;
-                }
-                let mut tmp = tmp.unwrap();
-
-                if r > 0 && -tmp.eval > alpha {
-                    let n = self.alpha_beta(&mut new_pos, -alpha - 1, -alpha, depth - 1, ply + 1);
-                    if n.is_none() {
-                        return None
-                    }
-                    tmp = n.unwrap();
-                }
-
-                if alpha < -tmp.eval && -tmp.eval < beta {
-                    let n  = self.alpha_beta(&mut new_pos, -beta, -alpha, depth - 1, ply + 1);
-                    if n.is_none() {
-                        return None
-                    }
-                    tmp = n.unwrap();
-                }
-
-                tmp.eval = tmp.eval;
-                Some(tmp)
+                self.lmr_search(pos, mv, alpha, beta, depth, ply)
             };
 
             let next = n;
@@ -261,6 +222,53 @@ impl AlphaBeta {
         self.save(pos, best_move, bound, depth as u8);
 
         Some(best_move)
+    }
+
+    fn lmr_search(
+        &mut self,
+        pos: &mut BoardState,
+        mv: &EvaledMove,
+        alpha: isize,
+        beta: isize,
+        depth: u8,
+        ply: u8,
+    ) -> Option<EvaledMove> {
+        let is_leftmost_node = if ply % 2 == 0 {
+            alpha == NEG_INF && beta == INF
+        } else {
+            alpha == INF && beta == NEG_INF
+        };
+
+        let in_check = is_in_check(pos, &self.gen.lookup);
+        let mut r = 0;
+
+        let can_late_move_reduce =
+            !is_leftmost_node && !in_check && !mv.mv.is_capture() && !mv.mv.is_promotion();
+
+        if can_late_move_reduce && depth > 2 {
+            r += 1;
+            if depth > 4 {
+                r += depth / 4;
+            }
+        }
+
+        let tmp = self.alpha_beta(pos, -alpha - 1, -alpha, depth - r - 1, ply + 1);
+        tmp?;
+        let mut tmp = tmp.unwrap();
+
+        if r > 0 && -tmp.eval > alpha {
+            let n = self.alpha_beta(pos, -alpha - 1, -alpha, depth - 1, ply + 1);
+            n?;
+            tmp = n.unwrap();
+        }
+
+        if alpha < -tmp.eval && -tmp.eval < beta {
+            let n = self.alpha_beta(pos, -beta, -alpha, depth - 1, ply + 1);
+            n?;
+            tmp = n.unwrap();
+        }
+
+        Some(tmp)
     }
 
     /// Perform a Quiescence search, which evaluates up to a certain provided maximum depth

--- a/src/search/alpha_beta.rs
+++ b/src/search/alpha_beta.rs
@@ -192,7 +192,7 @@ impl AlphaBeta {
                 is_first_move = false;
                 self.alpha_beta(&mut new_pos, -beta, -alpha, depth - 1, ply + 1)
             } else {
-                self.lmr_search(pos, mv, alpha, beta, depth, ply)
+                self.lmr_search(&mut new_pos, mv, alpha, beta, depth, ply)
             };
 
             let next = n;

--- a/src/search/alpha_beta.rs
+++ b/src/search/alpha_beta.rs
@@ -168,11 +168,10 @@ impl AlphaBeta {
 
         // If we haven't found a best move to search first yet, and we are on a left-most node,
         // then perform an IID search to determine the best node to search first
-        if moves.is_empty() && depth > 3 {
-            if is_leftmost_node {
-                if let Some(e) = self.alpha_beta(pos, alpha, beta, depth / 2, ply + 1) {
-                    moves.push(e);
-                }
+        let can_perform_iid = moves.is_empty() && depth > 3 && is_leftmost_node;
+        if can_perform_iid {
+            if let Some(e) = self.alpha_beta(pos, alpha, beta, depth / 2, ply + 1) {
+                moves.push(e);
             }
         }
 
@@ -188,15 +187,13 @@ impl AlphaBeta {
         for mv in &mut moves {
             let mut new_pos = pos.clone_with_move(mv.mv);
 
-            let n = if is_first_move {
+            let next = if is_first_move {
                 is_first_move = false;
                 self.alpha_beta(&mut new_pos, -beta, -alpha, depth - 1, ply + 1)
             } else {
                 self.lmr_search(&mut new_pos, mv, alpha, beta, depth, ply)
             };
 
-            let next = n;
-            //let next = self.alpha_beta(&mut new_pos, -beta, -alpha, depth - 1, ply + 1);
             self.stats.count_node();
             if next.is_none() {
                 return next;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -31,7 +31,8 @@ pub fn uci_loop() {
 
 fn go(pos: &mut BoardState, searcher: &mut AlphaBeta, data: &[&str]) {
     let movetime = data[2].parse::<u64>().unwrap();
-    searcher.move_time((movetime / 1000) - 1);
+    //searcher.move_time((movetime / 1000) - 1);
+    searcher.move_time(movetime / 1000);
     let mv = searcher.best_move_depth(pos, 15);
     println!("eval: {}", mv.eval);
     println!("static eval: {}", eval(pos));


### PR DESCRIPTION
Implements [Late move reduction](https://www.chessprogramming.org/Late_Move_Reductions)

```
Score of LMR_Purple vs Purple: 36 - 15 - 49  [0.605] 100
...      LMR_Purple playing White: 18 - 8 - 24  [0.600] 50
...      LMR_Purple playing Black: 18 - 7 - 25  [0.610] 50
...      White vs Black: 25 - 26 - 49  [0.495] 100
Elo difference: 74.1 +/- 48.9, LOS: 99.8 %, DrawRatio: 49.0 %
```

Note that there are many draws by three-fold repetition. `purple` does not currently support detection of loss by three fold repetition, so we should add that at some point...